### PR TITLE
Fix publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,14 +14,10 @@ jobs:
       fail-fast: false
       matrix:
         settings:
+          - platform: "macos-latest-large"
           - platform: "macos-latest"
-            args: "--target x86_64-apple-darwin"
-          - platform: "macos-latest"
-            args: "--target aarch64-apple-darwin"
           - platform: "ubuntu-22.04"
-            args: ""
           - platform: "windows-latest"
-            args: ""
 
     runs-on: ${{ matrix.settings.platform }}
     steps:
@@ -34,8 +30,6 @@ jobs:
 
       - name: install Rust stable
         uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: aarch64-apple-darwin,x86_64-apple-darwin
 
       - name: install dependencies (ubuntu only)
         if: matrix.settings.platform == 'ubuntu-22.04'


### PR DESCRIPTION
now `macos-latest` is Arm46, and `macos-latest-large` is Intel

- https://github.com/actions/runner-images/blob/30f313be541b7bdae9563e81e088a74e96911460/README.md#available-images
- https://docs.github.com/en/actions/using-github-hosted-runners/about-larger-runners/about-larger-runners#about-macos-larger-runners