### PR TITLE
Fix publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         settings:
-          - platform: "macos-latest-large"
+          - platform: "macos-13"
           - platform: "macos-latest"
           - platform: "ubuntu-22.04"
           - platform: "windows-latest"


### PR DESCRIPTION
> Larger runners are only available for organizations and enterprises using the GitHub Team or GitHub Enterprise Cloud plans.

https://docs.github.com/en/actions/using-github-hosted-runners/about-larger-runners/about-larger-runners